### PR TITLE
#263 Issue-fix: Initialize forceOpen in create_working_order rest.py

### DIFF
--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -1122,6 +1122,7 @@ class IGService:
             "size": size,
             "timeInForce": time_in_force,
             "type": order_type,
+            "forceOpen": 'false',
         }
         if limit_distance:
             params["limitDistance"] = limit_distance


### PR DESCRIPTION
Initializing forceOpen to 'false', which overrides default behaviour of 'true'.

If explicitly set `True` in function argument, it will be set to 'true' by existing flow.
Hence fixes the issue #263 