### PR TITLE
fix: bump requests-cache to ^0.9 to mitigate a Arbitrary Code Execution issue in version 0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,29 +31,27 @@ classifiers = [
 python = ">=3.7,<4.0"
 requests = "^2.24"
 pycryptodome = "^3.9"
-requests-cache = "^0.5"
+requests-cache = "^0.9"
 six = "^1.15"
 lightstreamer-client-lib = "^1.0.3"
 
 pandas = { version = "^1", optional = true }
 munch = { version = "^2.5", optional = true }
-tenacity = {version = "^8", optional = true}
+tenacity = { version = "^8", optional = true }
 
 [tool.poetry.extras]
 pandas = ["pandas"]
 munch = ["munch"]
 tenacity = ["tenacity"]
 sphinx = ["sphinx"]
-docs = [
-    "sphinx"
-]
+docs = ["sphinx"]
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^3.9"
 pytest = "^6.2"
 responses = "^0.12"
 coveralls = "^3.2"
-sphinx-rtd-theme = {version = "^1.0.0", optional = true}
+sphinx-rtd-theme = { version = "^1.0.0", optional = true }
 importlib-metadata = "==4.13.0"
 black = "23.3.0"
 


### PR DESCRIPTION
see https://security.snyk.io/vuln/SNYK-PYTHON-REQUESTSCACHE-1089050

tests were run before and after installation to compare, and the result were similar:
`17 failed, 92 passed, 3 skipped, 196 warnings, 49 errors`

Most of the issues in the test suite were related to: 
`Failed: Integration test currently only works with a spreadbet account`
