### PR TITLE
feature: added feature to request repeat dealing window for traded epics

### DIFF
--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -1393,7 +1393,7 @@ class IGService:
         Returns repeat dealing window status for account
         :param epic: filter epic, optional
         :type epic: str
-        :param session: session object, otional
+        :param session: session object, optional
         :type session: Session
         :return: repeat dealing windows for recently traded epics
         :rtype: dict

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -1402,7 +1402,7 @@ class IGService:
         version = "1"
         params = {}
         if epic is not None:
-            params["epic"] = epic            
+            params["epic"] = epic
         endpoint = "/repeat-dealing-window"
         action = "read"
         for i in range(5):

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -1387,6 +1387,33 @@ class IGService:
             return self.fetch_deal_by_deal_reference(deal_reference)
         else:
             raise IGException(response.text)
+        
+    def fetch_repeat_dealing_window(self, epic=None, session=None):
+        """
+        Returns repeat dealing window status for account
+        :param epic: filter epic, optional
+        :type epic: str
+        :param session: session object, otional
+        :type session: Session
+        :return: repeat dealing windows for recently traded epics
+        :rtype: dict
+        """
+        self.non_trading_rate_limit_pause_or_pass()
+        version = "1"
+        params = {}
+        if epic is not None:
+            params["epic"] = epic            
+        endpoint = "/repeat-dealing-window"
+        action = "read"
+        for i in range(5):
+            response = self._req(action, endpoint, params, session, version)
+            if not response.status_code == 200:
+                logger.info("Error fetching repeat dealing window, retrying.")
+                time.sleep(1)
+            else:
+                break
+        data = self.parse_response(response.text)
+        return data
 
     # -------- END -------- #
 

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -1387,7 +1387,7 @@ class IGService:
             return self.fetch_deal_by_deal_reference(deal_reference)
         else:
             raise IGException(response.text)
-        
+
     def fetch_repeat_dealing_window(self, epic=None, session=None):
         """
         Returns repeat dealing window status for account


### PR DESCRIPTION
Hi, there are have been some updates to IG's API, to support their new Price In Size dealing. It means you have different price (or increasing spread) for larger size orders. The most important part is the new PRICE stream.

If you trade an epic, there is time window in which the size accumulates for multiple deals. This REST feature (repeat dealing window) gets the time for your account to reset, for each epic that has a window (that has been recently traded). For more info, see the IG Labs documentation.